### PR TITLE
Fix duplicate flags group in emoji 13.1 ordering

### DIFF
--- a/emoji_13_1_ordering.json
+++ b/emoji_13_1_ordering.json
@@ -17451,7 +17451,7 @@
     ]
   },
   {
-    "group": "Flags",
+    "group": "Activities",
     "emoji": [
       {
         "base": [


### PR DESCRIPTION
Seems to be activities based on https://github.com/googlefonts/emoji-metadata/blob/main/emoji_13_0_ordering.json#L15109