### PR TITLE
Fix typo in emoji name for congratulations.

### DIFF
--- a/emoji_14_0_ordering.json
+++ b/emoji_14_0_ordering.json
@@ -26029,7 +26029,7 @@
         "alternates": [],
         "emoticons": [],
         "shortcodes": [
-          ":congratultions:"
+          ":congratulations:"
         ]
       },
       {


### PR DESCRIPTION
I noticed this while using Google Chat - it seems that there is a typo in the code for the ㊗️  emoji shortcode, which should be spelled :congratul**a**tions and not :congratultions.