### PR TITLE
Update 15.0 emoji metadata

### DIFF
--- a/emoji_15_0_ordering.json
+++ b/emoji_15_0_ordering.json
@@ -990,7 +990,7 @@
         "shortcodes": [
           ":mouth-open:"
         ],
-        "animated": false
+        "animated": true
       },
       {
         "base": [

--- a/emoji_15_0_ordering.json
+++ b/emoji_15_0_ordering.json
@@ -394,7 +394,8 @@
         ],
         "alternates": [],
         "emoticons": [
-          ":b"
+          ":P",
+          ":p"
         ],
         "shortcodes": [
           ":yum:"
@@ -407,8 +408,8 @@
         ],
         "alternates": [],
         "emoticons": [
-          ":p",
-          ":P"
+          ":-P",
+          ":-p"
         ],
         "shortcodes": [
           ":stuck-out-tongue:"
@@ -1004,7 +1005,7 @@
           ":surprised:",
           ":hushed:"
         ],
-        "animated": true
+        "animated": false
       },
       {
         "base": [


### PR DESCRIPTION
This asset is available on the CDN for 15.0:
https://fonts.gstatic.com/s/e/notoemoji/15.0/1f62e/512.webp